### PR TITLE
Feat/add auto index

### DIFF
--- a/packages/gwanli-core/src/index.ts
+++ b/packages/gwanli-core/src/index.ts
@@ -2,7 +2,7 @@
 export { listFiles } from "./lib/workspace-explorer.js";
 
 // Export notion functionality
-export { indexNotionPages, createPageFromMarkdown, replaceParagraph } from "./lib/notion.js";
+export { indexNotionPages, createPageFromMarkdown, replaceParagraph, appendToPage } from "./lib/notion.js";
 
 // Export job management
 export { JobTracker, getRecentJobs, getJobById } from "./lib/jobs.js";

--- a/packages/gwanli-mcp/src/tools/implementations/append.ts
+++ b/packages/gwanli-mcp/src/tools/implementations/append.ts
@@ -1,0 +1,105 @@
+import type { AppendArgs } from "../schemas.js";
+import type { McpResponse, ToolHandler } from "../types.js";
+import {
+  appendToPage,
+  loadConfig,
+} from "gwanli-core";
+
+export const appendHandler: ToolHandler<AppendArgs> = async (args) => {
+  try {
+    const config = loadConfig();
+    
+    if (!config.default_search) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No default search configured",
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const workspaceName = args.workspace || config.default_search;
+    const workspace = config.workspace[workspaceName];
+
+    if (!workspace) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Workspace '${workspaceName}' not found. Available workspaces: ${Object.keys(
+              config.workspace
+            ).join(", ")}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (!workspace.api_key) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `No API key configured for workspace '${workspaceName}'`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    try {
+      const pageId = await appendToPage(
+        workspace.api_key,
+        args.slug,
+        args.markdownContent,
+        workspace.db_path,
+        args.beforeBlockId,
+        args.afterBlockId
+      );
+
+      let positionMessage = "at the end of the page";
+      if (args.beforeBlockId) {
+        positionMessage = `before block ${args.beforeBlockId}`;
+      } else if (args.afterBlockId) {
+        positionMessage = `after block ${args.afterBlockId}`;
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Successfully appended content to page ${args.slug} ${positionMessage} (Page ID: ${pageId})`,
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Failed to append content to ${args.slug}: ${errorMessage}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error appending content: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        },
+      ],
+      isError: true,
+    };
+  }
+};

--- a/packages/gwanli-mcp/src/tools/implementations/append.ts
+++ b/packages/gwanli-mcp/src/tools/implementations/append.ts
@@ -56,15 +56,15 @@ export const appendHandler: ToolHandler<AppendArgs> = async (args) => {
         args.slug,
         args.markdownContent,
         workspace.db_path,
-        args.beforeBlockId,
-        args.afterBlockId
+        args.beforeBlockMarkdown,
+        args.afterBlockMarkdown
       );
 
       let positionMessage = "at the end of the page";
-      if (args.beforeBlockId) {
-        positionMessage = `before block ${args.beforeBlockId}`;
-      } else if (args.afterBlockId) {
-        positionMessage = `after block ${args.afterBlockId}`;
+      if (args.beforeBlockMarkdown) {
+        positionMessage = `before block containing "${args.beforeBlockMarkdown}"`;
+      } else if (args.afterBlockMarkdown) {
+        positionMessage = `after block containing "${args.afterBlockMarkdown}"`;
       }
 
       return {

--- a/packages/gwanli-mcp/src/tools/registry.ts
+++ b/packages/gwanli-mcp/src/tools/registry.ts
@@ -9,6 +9,7 @@ import { listJobsHandler, checkJobHandler } from "./implementations/jobs.js";
 import { listWorkspaceHandler } from "./implementations/listWorkspace.js";
 import { createPageHandler } from "./implementations/createPage.js";
 import { replaceContentHandler } from "./implementations/replaceContent.js";
+import { appendHandler } from "./implementations/append.js";
 
 // Tool handler registry with proper typing
 export const toolHandlers = {
@@ -23,6 +24,7 @@ export const toolHandlers = {
   listWorkspace: listWorkspaceHandler,
   createPage: createPageHandler,
   replaceContent: replaceContentHandler,
+  append: appendHandler,
 } as const;
 
 // Convert Zod schema to MCP-compatible JSON schema format

--- a/packages/gwanli-mcp/src/tools/schemas.ts
+++ b/packages/gwanli-mcp/src/tools/schemas.ts
@@ -251,7 +251,7 @@ export const ReplaceContentTool = {
 // Append Content tool schema
 export const AppendTool = {
   name: "append" as const,
-  description: "Append markdown content to a Notion page at a specific position or at the end",
+  description: "Append markdown content to a Notion page. Can position content before/after existing blocks by matching their text content, or append to the end if no position specified",
   inputSchema: z.object({
     slug: z
       .string()
@@ -261,14 +261,14 @@ export const AppendTool = {
       .string()
       .min(1)
       .describe("Markdown content to append to the page"),
-    beforeBlockId: z
+    beforeBlockMarkdown: z
       .string()
       .optional()
-      .describe("Block ID to insert content before - if provided, content will be inserted before this block"),
-    afterBlockId: z
+      .describe("Markdown content of the block to insert content before - content will be inserted before the first block containing this text"),
+    afterBlockMarkdown: z
       .string()
       .optional()
-      .describe("Block ID to insert content after - if provided, content will be inserted after this block"),
+      .describe("Markdown content of the block to insert content after - content will be inserted after the first block containing this text"),
     workspace: z
       .string()
       .optional()

--- a/packages/gwanli-mcp/src/tools/schemas.ts
+++ b/packages/gwanli-mcp/src/tools/schemas.ts
@@ -248,6 +248,34 @@ export const ReplaceContentTool = {
   }),
 } as const;
 
+// Append Content tool schema
+export const AppendTool = {
+  name: "append" as const,
+  description: "Append markdown content to a Notion page at a specific position or at the end",
+  inputSchema: z.object({
+    slug: z
+      .string()
+      .min(1)
+      .describe("Slug of the page to modify (must include leading slash, e.g., /home/personal/fitness)"),
+    markdownContent: z
+      .string()
+      .min(1)
+      .describe("Markdown content to append to the page"),
+    beforeBlockId: z
+      .string()
+      .optional()
+      .describe("Block ID to insert content before - if provided, content will be inserted before this block"),
+    afterBlockId: z
+      .string()
+      .optional()
+      .describe("Block ID to insert content after - if provided, content will be inserted after this block"),
+    workspace: z
+      .string()
+      .optional()
+      .describe("Workspace name to use - defaults to default_search from config"),
+  }),
+} as const;
+
 // Export all tools
 export const Tools = {
   auth: AuthTool,
@@ -261,6 +289,7 @@ export const Tools = {
   listWorkspace: ListWorkspaceTool,
   createPage: CreatePageTool,
   replaceContent: ReplaceContentTool,
+  append: AppendTool,
 } as const;
 
 // Generate TypeScript types
@@ -275,3 +304,4 @@ export type CheckJobArgs = z.infer<typeof CheckJobTool.inputSchema>;
 export type ListWorkspaceArgs = z.infer<typeof ListWorkspaceTool.inputSchema>;
 export type CreatePageArgs = z.infer<typeof CreatePageTool.inputSchema>;
 export type ReplaceContentArgs = z.infer<typeof ReplaceContentTool.inputSchema>;
+export type AppendArgs = z.infer<typeof AppendTool.inputSchema>;


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR
Introduced a new `append` tool for Notion, allowing users to programmatically add markdown content to existing pages with enhanced Notion-to-local database synchronization.

## Why we made these changes
To provide users with more granular control over Notion page content, enabling automation of content updates and ensuring better consistency between Notion and the local database.

## What changed?
- **`gwanli-core`**: Exported `appendToPage` function and enhanced `notion.ts` with auto-update, new page insertion, flexible markdown appending, and block finding utilities.
- **`gwanli-mcp`**: Added a new `appendHandler` tool to append markdown to Notion pages, registered it in the tool registry, and defined its input schema (`AppendTool`).

## Validation
- [ ] Successfully appended markdown to Notion pages via the new tool (at end, before/after specific blocks).
- [ ] Verified local database synchronization after Notion page modifications.
- [ ] Confirmed new Notion pages are correctly inserted into the local database.
- [ ] Ensured robust error handling for invalid tool inputs or Notion API failures.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/essencevc/settings/pull-requests)_</sup>
<!-- mesa-description-end -->